### PR TITLE
Add version command and embed build version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{matrix.goos}}
           goarch: ${{matrix.goarch}}
+          ldflags: "-X 'snek/cmd.Version=${{github.ref_name}}'"
           goversion: "1.24"
           project_path: "."
           binary_name: "snek"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+/*
+Copyright © 2025 David Doorn <djdoorn@che.nl>
+*/
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var Version string = "unknown"
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of snek",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("snek version", Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This pull request introduces a `version` command to the application, allowing users to retrieve the built application's version. The version is now embedded during the build process to ensure accuracy and consistency. No additional changes beyond the commit specified were made.